### PR TITLE
Remove absolute paths from artmap

### DIFF
--- a/artmap.json
+++ b/artmap.json
@@ -1,4127 +1,4127 @@
 {
     "abomasnow": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/460"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/460"
         }
     },
     "abra": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/063"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/063"
         }
     },
     "absol": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/359"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/359"
         }
     },
     "accelgor": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/617"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/617"
         }
     },
     "aegislash-blade": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/681"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/681"
         }
     },
     "aegislash-shield": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/681"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/681"
         }
     },
     "aerodactyl": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/142"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/142"
         }
     },
     "aggron": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/306"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/306"
         }
     },
     "aipom": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/190"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/190"
         }
     },
     "alakazam": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/065"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/065"
         }
     },
     "alcremie": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/869"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/869"
         }
     },
     "alolan-diglett": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/050"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/050"
         }
     },
     "alolan-dugtrio": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/051"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/051"
         }
     },
     "alolan-exeggutor": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/103"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/103"
         }
     },
     "alolan-geodude": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/074"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/074"
         }
     },
     "alolan-golem": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/076"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/076"
         }
     },
     "alolan-graveler": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/075"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/075"
         }
     },
     "alolan-grimer": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/088"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/088"
         }
     },
     "alolan-marowak": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/105"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/105"
         }
     },
     "alolan-meowth": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/052"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/052"
         }
     },
     "alolan-muk": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/089"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/089"
         }
     },
     "alolan-ninetales": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/038"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/038"
         }
     },
     "alolan-persian": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/053"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/053"
         }
     },
     "alolan-raichu": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/026"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/026"
         }
     },
     "alolan-raticate": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/020"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/020"
         }
     },
     "alolan-rattata": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/019"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/019"
         }
     },
     "alolan-sandshrew": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/027"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/027"
         }
     },
     "alolan-sandslash": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/028"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/028"
         }
     },
     "alolan-vulpix": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/037"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/037"
         }
     },
     "alomomola": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/594"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/594"
         }
     },
     "altaria": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/334"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/334"
         }
     },
     "amaura": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/698"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/698"
         }
     },
     "ambipom": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/424"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/424"
         }
     },
     "amoonguss": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/591"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/591"
         }
     },
     "ampharos": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/181"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/181"
         }
     },
     "annihilape": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/979"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/979"
         }
     },
     "anorith": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/347"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/347"
         }
     },
     "appletun": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/842"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/842"
         }
     },
     "applin": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/840"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/840"
         }
     },
     "araquanid": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/752"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/752"
         }
     },
     "arbok": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/024"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/024"
         }
     },
     "arboliva": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/930"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/930"
         }
     },
     "arcanine": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/059"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/059"
         }
     },
     "arceus": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/493"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/493"
         }
     },
     "archaludon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1018"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1018"
         }
     },
     "archen": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/566"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/566"
         }
     },
     "archeops": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/567"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/567"
         }
     },
     "arctibax": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/997"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/997"
         }
     },
     "arctovish": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/883"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/883"
         }
     },
     "arctozolt": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/881"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/881"
         }
     },
     "ariados": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/168"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/168"
         }
     },
     "armaldo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/348"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/348"
         }
     },
     "armarouge": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/936"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/936"
         }
     },
     "aromatisse": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/683"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/683"
         }
     },
     "aron": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/304"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/304"
         }
     },
     "arrokuda": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/846"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/846"
         }
     },
     "articuno": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/144"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/144"
         }
     },
     "audino": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/531"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/531"
         }
     },
     "aurorus": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/699"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/699"
         }
     },
     "avalugg": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/713"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/713"
         }
     },
     "axew": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/610"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/610"
         }
     },
     "azelf": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/482"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/482"
         }
     },
     "azumarill": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/184"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/184"
         }
     },
     "azurill": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/298"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/298"
         }
     },
     "bagon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/371"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/371"
         }
     },
     "baltoy": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/343"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/343"
         }
     },
     "banette": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/354"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/354"
         }
     },
     "barbaracle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/689"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/689"
         }
     },
     "barboach": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/339"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/339"
         }
     },
     "barraskewda": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/847"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/847"
         }
     },
     "basculegion-female": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/902"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/902"
         }
     },
     "basculegion-male": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/902"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/902"
         }
     },
     "basculin": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/550"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/550"
         }
     },
     "bastiodon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/411"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/411"
         }
     },
     "baxcalibur": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/998"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/998"
         }
     },
     "bayleef": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/153"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/153"
         }
     },
     "beartic": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/614"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/614"
         }
     },
     "beautifly": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/267"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/267"
         }
     },
     "beedrill": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/015"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/015"
         }
     },
     "beheeyem": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/606"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/606"
         }
     },
     "beldum": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/374"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/374"
         }
     },
     "bellibolt": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/939"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/939"
         }
     },
     "bellossom": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/182"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/182"
         }
     },
     "bellsprout": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/069"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/069"
         }
     },
     "bergmite": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/712"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/712"
         }
     },
     "bewear": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/760"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/760"
         }
     },
     "bibarel": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/400"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/400"
         }
     },
     "bidoof": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/399"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/399"
         }
     },
     "binacle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/688"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/688"
         }
     },
     "bisharp": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/625"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/625"
         }
     },
     "blacephalon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/806"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/806"
         }
     },
     "blastoise": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/009"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/009"
         }
     },
     "blaziken": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/257"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/257"
         }
     },
     "blipbug": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/824"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/824"
         }
     },
     "blissey": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/242"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/242"
         }
     },
     "blitzle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/522"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/522"
         }
     },
     "boldore": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/525"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/525"
         }
     },
     "boltund": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/836"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/836"
         }
     },
     "bombirdier": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/962"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/962"
         }
     },
     "bonsly": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/438"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/438"
         }
     },
     "bouffalant": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/626"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/626"
         }
     },
     "bounsweet": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/761"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/761"
         }
     },
     "braixen": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/654"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/654"
         }
     },
     "brambleghast": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/947"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/947"
         }
     },
     "bramblin": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/946"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/946"
         }
     },
     "braviary": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/628"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/628"
         }
     },
     "breloom": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/286"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/286"
         }
     },
     "brionne": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/729"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/729"
         }
     },
     "bronzong": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/437"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/437"
         }
     },
     "bronzor": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/436"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/436"
         }
     },
     "brute-bonnet": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/986"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/986"
         }
     },
     "bruxish": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/779"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/779"
         }
     },
     "budew": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/406"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/406"
         }
     },
     "buizel": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/418"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/418"
         }
     },
     "bulbasaur": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/001"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/001"
         }
     },
     "buneary": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/427"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/427"
         }
     },
     "bunnelby": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/659"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/659"
         }
     },
     "burmy": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/412"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/412"
         }
     },
     "butterfree": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/012"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/012"
         }
     },
     "buzzwole": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/794"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/794"
         }
     },
     "cacnea": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/331"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/331"
         }
     },
     "cacturne": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/332"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/332"
         }
     },
     "calyrex": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/898"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/898"
         }
     },
     "calyrex-ice-rider": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/898"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/898"
         }
     },
     "calyrex-shadow-rider": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/898"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/898"
         }
     },
     "camerupt": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/323"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/323"
         }
     },
     "capsakid": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/951"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/951"
         }
     },
     "carbink": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/703"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/703"
         }
     },
     "carkol": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/838"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/838"
         }
     },
     "carnivine": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/455"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/455"
         }
     },
     "carracosta": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/565"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/565"
         }
     },
     "carvanha": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/318"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/318"
         }
     },
     "cascoon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/268"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/268"
         }
     },
     "castform": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/351"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/351"
         }
     },
     "caterpie": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/010"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/010"
         }
     },
     "celebi": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/251"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/251"
         }
     },
     "celesteela": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/797"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/797"
         }
     },
     "centiskorch": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/851"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/851"
         }
     },
     "ceruledge": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/937"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/937"
         }
     },
     "cetitan": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/975"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/975"
         }
     },
     "cetoddle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/974"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/974"
         }
     },
     "chandelure": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/609"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/609"
         }
     },
     "chansey": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/113"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/113"
         }
     },
     "charcadet": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/935"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/935"
         }
     },
     "charizard": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/006"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/006"
         }
     },
     "charjabug": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/737"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/737"
         }
     },
     "charmander": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/004"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/004"
         }
     },
     "charmeleon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/005"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/005"
         }
     },
     "chatot": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/441"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/441"
         }
     },
     "cherrim": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/421"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/421"
         }
     },
     "cherubi": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/420"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/420"
         }
     },
     "chesnaught": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/652"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/652"
         }
     },
     "chespin": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/650"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/650"
         }
     },
     "chewtle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/833"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/833"
         }
     },
     "chi-yu": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1004"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1004"
         }
     },
     "chien-pao": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1002"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1002"
         }
     },
     "chikorita": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/152"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/152"
         }
     },
     "chimchar": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/390"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/390"
         }
     },
     "chimecho": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/358"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/358"
         }
     },
     "chinchou": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/170"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/170"
         }
     },
     "chingling": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/433"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/433"
         }
     },
     "cinccino": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/573"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/573"
         }
     },
     "cinderace": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/815"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/815"
         }
     },
     "clamperl": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/366"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/366"
         }
     },
     "clauncher": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/692"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/692"
         }
     },
     "clawitzer": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/693"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/693"
         }
     },
     "claydol": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/344"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/344"
         }
     },
     "clefable": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/036"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/036"
         }
     },
     "clefairy": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/035"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/035"
         }
     },
     "cleffa": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/174"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/174"
         }
     },
     "clobbopus": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/852"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/852"
         }
     },
     "clodsire": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/980"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/980"
         }
     },
     "cloyster": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/091"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/091"
         }
     },
     "coalossal": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/839"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/839"
         }
     },
     "cobalion": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/638"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/638"
         }
     },
     "cofagrigus": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/563"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/563"
         }
     },
     "combee": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/415"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/415"
         }
     },
     "combusken": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/256"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/256"
         }
     },
     "comfey": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/764"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/764"
         }
     },
     "conkeldurr": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/534"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/534"
         }
     },
     "copperajah": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/879"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/879"
         }
     },
     "corphish": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/341"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/341"
         }
     },
     "corsola": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/222"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/222"
         }
     },
     "corviknight": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/823"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/823"
         }
     },
     "corvisquire": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/822"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/822"
         }
     },
     "cosmoem": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/790"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/790"
         }
     },
     "cosmog": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/789"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/789"
         }
     },
     "cottonee": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/546"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/546"
         }
     },
     "crabominable": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/740"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/740"
         }
     },
     "crabrawler": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/739"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/739"
         }
     },
     "cradily": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/346"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/346"
         }
     },
     "cramorant": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/845"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/845"
         }
     },
     "cranidos": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/408"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/408"
         }
     },
     "crawdaunt": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/342"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/342"
         }
     },
     "cresselia": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/488"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/488"
         }
     },
     "croagunk": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/453"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/453"
         }
     },
     "crobat": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/169"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/169"
         }
     },
     "crocalor": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/910"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/910"
         }
     },
     "croconaw": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/159"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/159"
         }
     },
     "crustle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/558"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/558"
         }
     },
     "cryogonal": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/615"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/615"
         }
     },
     "cubchoo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/613"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/613"
         }
     },
     "cubone": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/104"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/104"
         }
     },
     "cufant": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/878"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/878"
         }
     },
     "cursola": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/864"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/864"
         }
     },
     "cutiefly": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/742"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/742"
         }
     },
     "cyclizar": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/967"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/967"
         }
     },
     "cyndaquil": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/155"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/155"
         }
     },
     "dachsbun": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/927"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/927"
         }
     },
     "darkrai": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/491"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/491"
         }
     },
     "darmanitan-standard": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/555"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/555"
         }
     },
     "darmanitan-zen": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/555"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/555"
         }
     },
     "dartrix": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/723"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/723"
         }
     },
     "darumaka": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/554"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/554"
         }
     },
     "decidueye": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/724"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/724"
         }
     },
     "dedenne": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/702"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/702"
         }
     },
     "deerling": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/585"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/585"
         }
     },
     "deino": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/633"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/633"
         }
     },
     "delcatty": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/301"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/301"
         }
     },
     "delibird": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/225"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/225"
         }
     },
     "delphox": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/655"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/655"
         }
     },
     "deoxys-normal": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/386"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/386"
         }
     },
     "dewgong": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/087"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/087"
         }
     },
     "dewott": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/502"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/502"
         }
     },
     "dewpider": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/751"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/751"
         }
     },
     "dhelmise": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/781"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/781"
         }
     },
     "dialga": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/483"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/483"
         }
     },
     "dialga-origin": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/483"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/483"
         }
     },
     "diancie": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/719"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/719"
         }
     },
     "diggersby": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/660"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/660"
         }
     },
     "diglett": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/050"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/050"
         }
     },
     "dipplin": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1011"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1011"
         }
     },
     "ditto": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/132"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/132"
         }
     },
     "dodrio": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/085"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/085"
         }
     },
     "doduo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/084"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/084"
         }
     },
     "dolliv": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/929"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/929"
         }
     },
     "dondozo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/977"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/977"
         }
     },
     "donphan": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/232"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/232"
         }
     },
     "dottler": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/825"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/825"
         }
     },
     "doublade": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/680"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/680"
         }
     },
     "dracovish": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/882"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/882"
         }
     },
     "dracozolt": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/880"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/880"
         }
     },
     "dragalge": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/691"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/691"
         }
     },
     "dragapult": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/887"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/887"
         }
     },
     "dragonair": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/148"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/148"
         }
     },
     "dragonite": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/149"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/149"
         }
     },
     "drakloak": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/886"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/886"
         }
     },
     "drampa": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/780"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/780"
         }
     },
     "drapion": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/452"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/452"
         }
     },
     "dratini": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/147"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/147"
         }
     },
     "drednaw": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/834"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/834"
         }
     },
     "dreepy": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/885"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/885"
         }
     },
     "drifblim": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/426"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/426"
         }
     },
     "drifloon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/425"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/425"
         }
     },
     "drilbur": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/529"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/529"
         }
     },
     "drizzile": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/817"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/817"
         }
     },
     "drowzee": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/096"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/096"
         }
     },
     "druddigon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/621"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/621"
         }
     },
     "dubwool": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/832"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/832"
         }
     },
     "ducklett": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/580"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/580"
         }
     },
     "dudunsparce": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/982"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/982"
         }
     },
     "dugtrio": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/051"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/051"
         }
     },
     "dunsparce": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/206"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/206"
         }
     },
     "duosion": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/578"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/578"
         }
     },
     "duraludon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/884"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/884"
         }
     },
     "durant": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/632"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/632"
         }
     },
     "dusclops": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/356"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/356"
         }
     },
     "dusknoir": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/477"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/477"
         }
     },
     "duskull": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/355"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/355"
         }
     },
     "dustox": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/269"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/269"
         }
     },
     "dwebble": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/557"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/557"
         }
     },
     "eelektrik": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/603"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/603"
         }
     },
     "eelektross": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/604"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/604"
         }
     },
     "eevee": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/133"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/133"
         }
     },
     "eiscue-ice": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/875"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/875"
         }
     },
     "eiscue-noice": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/875"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/875"
         }
     },
     "ekans": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/023"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/023"
         }
     },
     "eldegoss": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/830"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/830"
         }
     },
     "electabuzz": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/125"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/125"
         }
     },
     "electivire": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/466"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/466"
         }
     },
     "electrike": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/309"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/309"
         }
     },
     "electrode": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/101"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/101"
         }
     },
     "elekid": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/239"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/239"
         }
     },
     "elgyem": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/605"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/605"
         }
     },
     "emboar": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/500"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/500"
         }
     },
     "emolga": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/587"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/587"
         }
     },
     "empoleon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/395"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/395"
         }
     },
     "enamorus-incarnate": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/905"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/905"
         }
     },
     "enamorus-therian": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/905"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/905"
         }
     },
     "entei": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/244"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/244"
         }
     },
     "escavalier": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/589"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/589"
         }
     },
     "espathra": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/956"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/956"
         }
     },
     "espeon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/196"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/196"
         }
     },
     "espurr": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/677"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/677"
         }
     },
     "eternatus": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/890"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/890"
         }
     },
     "eternatus-eternamax": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/890"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/890"
         }
     },
     "excadrill": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/530"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/530"
         }
     },
     "exeggcute": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/102"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/102"
         }
     },
     "exeggutor": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/103"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/103"
         }
     },
     "exploud": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/295"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/295"
         }
     },
     "falinks": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/870"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/870"
         }
     },
     "farfetchd": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/083"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/083"
         }
     },
     "farigiraf": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/981"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/981"
         }
     },
     "fearow": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/022"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/022"
         }
     },
     "feebas": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/349"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/349"
         }
     },
     "fennekin": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/653"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/653"
         }
     },
     "feraligatr": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/160"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/160"
         }
     },
     "ferroseed": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/597"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/597"
         }
     },
     "ferrothorn": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/598"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/598"
         }
     },
     "fezandipiti": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1016"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1016"
         }
     },
     "fidough": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/926"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/926"
         }
     },
     "finizen": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/963"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/963"
         }
     },
     "finneon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/456"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/456"
         }
     },
     "flaaffy": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/180"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/180"
         }
     },
     "flabebe": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/669"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/669"
         }
     },
     "flamigo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/973"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/973"
         }
     },
     "flapple": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/841"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/841"
         }
     },
     "flareon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/136"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/136"
         }
     },
     "fletchinder": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/662"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/662"
         }
     },
     "fletchling": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/661"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/661"
         }
     },
     "flittle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/955"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/955"
         }
     },
     "floatzel": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/419"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/419"
         }
     },
     "floette": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/670"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/670"
         }
     },
     "floette-eternal": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/670"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/670"
         }
     },
     "floragato": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/907"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/907"
         }
     },
     "florges": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/671"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/671"
         }
     },
     "flutter-mane": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/987"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/987"
         }
     },
     "flygon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/330"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/330"
         }
     },
     "fomantis": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/753"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/753"
         }
     },
     "foongus": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/590"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/590"
         }
     },
     "forretress": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/205"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/205"
         }
     },
     "fraxure": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/611"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/611"
         }
     },
     "frigibax": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/996"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/996"
         }
     },
     "frillish": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/592"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/592"
         }
     },
     "froakie": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/656"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/656"
         }
     },
     "frogadier": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/657"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/657"
         }
     },
     "froslass": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/478"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/478"
         }
     },
     "frosmoth": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/873"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/873"
         }
     },
     "fuecoco": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/909"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/909"
         }
     },
     "furfrou": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/676"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/676"
         }
     },
     "furret": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/162"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/162"
         }
     },
     "gabite": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/444"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/444"
         }
     },
     "galarian-articuno": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/144"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/144"
         }
     },
     "galarian-corsola": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/222"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/222"
         }
     },
     "galarian-darmanitan": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/555"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/555"
         }
     },
     "galarian-darmanitan-zen": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/555"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/555"
         }
     },
     "galarian-darumaka": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/554"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/554"
         }
     },
     "galarian-farfetchd": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/083"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/083"
         }
     },
     "galarian-linoone": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/264"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/264"
         }
     },
     "galarian-meowth": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/052"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/052"
         }
     },
     "galarian-moltres": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/146"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/146"
         }
     },
     "galarian-mr-mime": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/122"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/122"
         }
     },
     "galarian-ponyta": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/077"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/077"
         }
     },
     "galarian-rapidash": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/078"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/078"
         }
     },
     "galarian-slowbro": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/080"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/080"
         }
     },
     "galarian-slowking": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/199"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/199"
         }
     },
     "galarian-slowpoke": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/079"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/079"
         }
     },
     "galarian-stunfisk": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/618"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/618"
         }
     },
     "galarian-weezing": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/110"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/110"
         }
     },
     "galarian-yamask": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/562"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/562"
         }
     },
     "galarian-zapdos": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/145"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/145"
         }
     },
     "galarian-zigzagoon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/263"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/263"
         }
     },
     "gallade": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/475"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/475"
         }
     },
     "galvantula": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/596"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/596"
         }
     },
     "garbodor": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/569"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/569"
         }
     },
     "garchomp": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/445"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/445"
         }
     },
     "gardevoir": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/282"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/282"
         }
     },
     "garganacl": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/934"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/934"
         }
     },
     "gastly": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/092"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/092"
         }
     },
     "gastrodon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/423"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/423"
         }
     },
     "genesect": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/649"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/649"
         }
     },
     "gengar": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/094"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/094"
         }
     },
     "geodude": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/074"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/074"
         }
     },
     "gholdengo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1000"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1000"
         }
     },
     "gible": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/443"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/443"
         }
     },
     "gigalith": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/526"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/526"
         }
     },
     "gimmighoul": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/999"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/999"
         }
     },
     "gimmighoul-roaming": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/999"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/999"
         }
     },
     "girafarig": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/203"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/203"
         }
     },
     "giratina-altered": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/487"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/487"
         }
     },
     "giratina-origin": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/487"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/487"
         }
     },
     "glaceon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/471"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/471"
         }
     },
     "glalie": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/362"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/362"
         }
     },
     "glameow": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/431"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/431"
         }
     },
     "glastrier": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/896"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/896"
         }
     },
     "gligar": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/207"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/207"
         }
     },
     "glimmet": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/969"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/969"
         }
     },
     "glimmora": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/970"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/970"
         }
     },
     "gliscor": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/472"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/472"
         }
     },
     "gloom": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/044"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/044"
         }
     },
     "gogoat": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/673"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/673"
         }
     },
     "golbat": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/042"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/042"
         }
     },
     "goldeen": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/118"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/118"
         }
     },
     "golduck": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/055"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/055"
         }
     },
     "golem": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/076"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/076"
         }
     },
     "golett": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/622"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/622"
         }
     },
     "golisopod": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/768"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/768"
         }
     },
     "golurk": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/623"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/623"
         }
     },
     "goodra": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/706"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/706"
         }
     },
     "goomy": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/704"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/704"
         }
     },
     "gorebyss": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/368"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/368"
         }
     },
     "gossifleur": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/829"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/829"
         }
     },
     "gothita": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/574"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/574"
         }
     },
     "gothitelle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/576"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/576"
         }
     },
     "gothorita": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/575"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/575"
         }
     },
     "gouging-fire": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1020"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1020"
         }
     },
     "gourgeist-average": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/711"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/711"
         }
     },
     "grafaiai": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/945"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/945"
         }
     },
     "granbull": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/210"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/210"
         }
     },
     "grapploct": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/853"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/853"
         }
     },
     "graveler": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/075"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/075"
         }
     },
     "great-tusk": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/984"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/984"
         }
     },
     "greavard": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/971"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/971"
         }
     },
     "greedent": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/820"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/820"
         }
     },
     "greninja": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/658"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/658"
         }
     },
     "grimer": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/088"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/088"
         }
     },
     "grimmsnarl": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/861"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/861"
         }
     },
     "grookey": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/810"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/810"
         }
     },
     "grotle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/388"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/388"
         }
     },
     "groudon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/383"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/383"
         }
     },
     "grovyle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/253"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/253"
         }
     },
     "growlithe": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/058"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/058"
         }
     },
     "grubbin": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/736"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/736"
         }
     },
     "grumpig": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/326"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/326"
         }
     },
     "gulpin": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/316"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/316"
         }
     },
     "gumshoos": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/735"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/735"
         }
     },
     "gurdurr": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/533"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/533"
         }
     },
     "guzzlord": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/799"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/799"
         }
     },
     "gyarados": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/130"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/130"
         }
     },
     "hakamo-o": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/783"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/783"
         }
     },
     "happiny": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/440"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/440"
         }
     },
     "hariyama": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/297"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/297"
         }
     },
     "hatenna": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/856"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/856"
         }
     },
     "hatterene": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/858"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/858"
         }
     },
     "hattrem": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/857"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/857"
         }
     },
     "haunter": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/093"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/093"
         }
     },
     "hawlucha": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/701"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/701"
         }
     },
     "haxorus": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/612"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/612"
         }
     },
     "heatmor": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/631"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/631"
         }
     },
     "heatran": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/485"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/485"
         }
     },
     "heliolisk": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/695"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/695"
         }
     },
     "helioptile": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/694"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/694"
         }
     },
     "heracross": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/214"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/214"
         }
     },
     "herdier": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/507"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/507"
         }
     },
     "hippopotas": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/449"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/449"
         }
     },
     "hippowdon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/450"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/450"
         }
     },
     "hisuian-arcanine": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/059"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/059"
         }
     },
     "hisuian-avalugg": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/713"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/713"
         }
     },
     "hisuian-braviary": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/628"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/628"
         }
     },
     "hisuian-decidueye": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/724"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/724"
         }
     },
     "hisuian-electrode": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/101"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/101"
         }
     },
     "hisuian-goodra": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/706"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/706"
         }
     },
     "hisuian-growlithe": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/058"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/058"
         }
     },
     "hisuian-lilligant": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/549"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/549"
         }
     },
     "hisuian-qwilfish": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/211"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/211"
         }
     },
     "hisuian-samurott": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/503"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/503"
         }
     },
     "hisuian-sliggoo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/705"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/705"
         }
     },
     "hisuian-sneasel": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/215"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/215"
         }
     },
     "hisuian-typhlosion": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/157"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/157"
         }
     },
     "hisuian-voltorb": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/100"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/100"
         }
     },
     "hisuian-zoroark": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/571"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/571"
         }
     },
     "hisuian-zorua": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/570"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/570"
         }
     },
     "hitmonchan": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/107"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/107"
         }
     },
     "hitmonlee": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/106"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/106"
         }
     },
     "hitmontop": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/237"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/237"
         }
     },
     "ho-oh": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/250"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/250"
         }
     },
     "honchkrow": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/430"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/430"
         }
     },
     "honedge": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/679"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/679"
         }
     },
     "hoopa": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/720"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/720"
         }
     },
     "hoopa-unbound": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/720"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/720"
         }
     },
     "hoothoot": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/163"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/163"
         }
     },
     "hoppip": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/187"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/187"
         }
     },
     "horsea": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/116"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/116"
         }
     },
     "houndoom": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/229"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/229"
         }
     },
     "houndour": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/228"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/228"
         }
     },
     "houndstone": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/972"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/972"
         }
     },
     "huntail": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/367"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/367"
         }
     },
     "hydrapple": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1019"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1019"
         }
     },
     "hydreigon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/635"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/635"
         }
     },
     "hypno": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/097"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/097"
         }
     },
     "igglybuff": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/174"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/174"
         }
     },
     "illumise": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/314"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/314"
         }
     },
     "impidimp": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/859"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/859"
         }
     },
     "incineroar": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/727"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/727"
         }
     },
     "indeedee-female": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/876"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/876"
         }
     },
     "indeedee-male": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/876"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/876"
         }
     },
     "infernape": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/392"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/392"
         }
     },
     "inkay": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/686"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/686"
         }
     },
     "inteleon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/818"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/818"
         }
     },
     "iron-boulder": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1022"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1022"
         }
     },
     "iron-bundle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/991"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/991"
         }
     },
     "iron-crown": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1023"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1023"
         }
     },
     "iron-hands": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/992"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/992"
         }
     },
     "iron-jugulis": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/993"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/993"
         }
     },
     "iron-leaves": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1010"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1010"
         }
     },
     "iron-moth": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/994"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/994"
         }
     },
     "iron-thorns": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/995"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/995"
         }
     },
     "iron-treads": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/990"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/990"
         }
     },
     "iron-valiant": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1006"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1006"
         }
     },
     "ivysaur": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/002"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/002"
         }
     },
     "jangmo-o": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/782"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/782"
         }
     },
     "jellicent": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/593"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/593"
         }
     },
     "jigglypuff": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/039"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/039"
         }
     },
     "jirachi": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/385"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/385"
         }
     },
     "jolteon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/135"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/135"
         }
     },
     "joltik": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/595"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/595"
         }
     },
     "jumpluff": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/189"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/189"
         }
     },
     "jynx": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/124"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/124"
         }
     },
     "kabuto": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/140"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/140"
         }
     },
     "kabutops": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/141"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/141"
         }
     },
     "kadabra": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/064"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/064"
         }
     },
     "kakuna": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/014"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/014"
         }
     },
     "kangaskhan": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/115"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/115"
         }
     },
     "karrablast": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/588"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/588"
         }
     },
     "kartana": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/798"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/798"
         }
     },
     "kecleon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/352"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/352"
         }
     },
     "keldeo-ordinary": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/647"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/647"
         }
     },
     "keldeo-resolute": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/647"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/647"
         }
     },
     "kilowattrel": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/941"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/941"
         }
     },
     "kingambit": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/983"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/983"
         }
     },
     "kingdra": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/230"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/230"
         }
     },
     "kingler": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/099"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/099"
         }
     },
     "kirlia": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/281"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/281"
         }
     },
     "klang": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/600"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/600"
         }
     },
     "klawf": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/950"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/950"
         }
     },
     "kleavor": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/900"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/900"
         }
     },
     "klefki": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/707"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/707"
         }
     },
     "klink": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/599"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/599"
         }
     },
     "klinklang": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/601"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/601"
         }
     },
     "koffing": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/109"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/109"
         }
     },
     "komala": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/775"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/775"
         }
     },
     "kommo-o": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/784"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/784"
         }
     },
     "koraidon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1007"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1007"
         }
     },
     "krabby": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/098"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/098"
         }
     },
     "kricketot": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/401"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/401"
         }
     },
     "kricketune": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/402"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/402"
         }
     },
     "krokorok": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/552"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/552"
         }
     },
     "krookodile": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/553"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/553"
         }
     },
     "kubfu": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/891"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/891"
         }
     },
     "kyogre": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/382"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/382"
         }
     },
     "kyurem": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/646"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/646"
         }
     },
     "kyurem-black": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/646"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/646"
         }
     },
     "kyurem-white": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/646"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/646"
         }
     },
     "lairon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/305"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/305"
         }
     },
     "lampent": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/608"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/608"
         }
     },
     "landorus-incarnate": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/645"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/645"
         }
     },
     "landorus-therian": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/645"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/645"
         }
     },
     "lanturn": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/171"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/171"
         }
     },
     "lapras": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/131"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/131"
         }
     },
     "larvesta": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/636"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/636"
         }
     },
     "larvitar": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/246"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/246"
         }
     },
     "latias": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/380"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/380"
         }
     },
     "latios": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/381"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/381"
         }
     },
     "leafeon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/470"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/470"
         }
     },
     "leavanny": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/542"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/542"
         }
     },
     "lechonk": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/915"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/915"
         }
     },
     "ledian": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/166"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/166"
         }
     },
     "ledyba": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/165"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/165"
         }
     },
     "lickilicky": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/463"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/463"
         }
     },
     "lickitung": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/108"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/108"
         }
     },
     "liepard": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/510"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/510"
         }
     },
     "lileep": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/345"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/345"
         }
     },
     "lilligant": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/549"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/549"
         }
     },
     "lillipup": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/506"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/506"
         }
     },
     "linoone": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/264"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/264"
         }
     },
     "litleo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/667"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/667"
         }
     },
     "litten": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/725"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/725"
         }
     },
     "litwick": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/607"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/607"
         }
     },
     "lokix": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/920"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/920"
         }
     },
     "lombre": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/271"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/271"
         }
     },
     "lopunny": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/428"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/428"
         }
     },
     "lotad": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/270"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/270"
         }
     },
     "loudred": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/294"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/294"
         }
     },
     "lucario": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/448"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/448"
         }
     },
     "ludicolo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/272"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/272"
         }
     },
     "lugia": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/249"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/249"
         }
     },
     "lumineon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/457"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/457"
         }
     },
     "lunala": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/792"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/792"
         }
     },
     "lunatone": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/337"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/337"
         }
     },
     "lurantis": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/754"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/754"
         }
     },
     "luvdisc": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/370"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/370"
         }
     },
     "luxio": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/404"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/404"
         }
     },
     "luxray": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/405"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/405"
         }
     },
     "lycanroc-dusk": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/745"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/745"
         }
     },
     "lycanroc-midday": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/745"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/745"
         }
     },
     "lycanroc-midnight": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/745"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/745"
         }
     },
     "mabosstiff": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/943"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/943"
         }
     },
     "machamp": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/068"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/068"
         }
     },
     "machoke": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/067"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/067"
         }
     },
     "machop": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/066"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/066"
         }
     },
     "magby": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/240"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/240"
         }
     },
     "magcargo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/219"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/219"
         }
     },
     "magearna": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/801"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/801"
         }
     },
     "magikarp": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/129"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/129"
         }
     },
     "magmar": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/126"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/126"
         }
     },
     "magmortar": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/467"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/467"
         }
     },
     "magnemite": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/081"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/081"
         }
     },
     "magneton": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/082"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/082"
         }
     },
     "magnezone": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/462"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/462"
         }
     },
     "makuhita": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/296"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/296"
         }
     },
     "malamar": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/687"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/687"
         }
     },
     "mamoswine": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/473"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/473"
         }
     },
     "manaphy": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/490"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/490"
         }
     },
     "mandibuzz": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/630"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/630"
         }
     },
     "manectric": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/310"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/310"
         }
     },
     "mankey": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/056"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/056"
         }
     },
     "mantine": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/226"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/226"
         }
     },
     "mantyke": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/458"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/458"
         }
     },
     "maractus": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/556"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/556"
         }
     },
     "mareanie": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/747"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/747"
         }
     },
     "mareep": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/179"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/179"
         }
     },
     "marill": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/183"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/183"
         }
     },
     "marowak": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/105"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/105"
         }
     },
     "marshadow": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/802"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/802"
         }
     },
     "marshtomp": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/259"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/259"
         }
     },
     "maschiff": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/942"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/942"
         }
     },
     "masquerain": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/284"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/284"
         }
     },
     "maushold": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/925"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/925"
         }
     },
     "mawile": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/303"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/303"
         }
     },
     "medicham": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/308"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/308"
         }
     },
     "meditite": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/307"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/307"
         }
     },
     "meganium": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/154"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/154"
         }
     },
     "melmetal": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/809"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/809"
         }
     },
     "meloetta-aria": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/648"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/648"
         }
     },
     "meloetta-pirouette": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/648"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/648"
         }
     },
     "meltan": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/808"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/808"
         }
     },
     "meowscarada": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/908"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/908"
         }
     },
     "meowstic-female": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/678"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/678"
         }
     },
     "meowstic-male": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/678"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/678"
         }
     },
     "meowth": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/052"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/052"
         }
     },
     "mesprit": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/481"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/481"
         }
     },
     "metagross": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/376"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/376"
         }
     },
     "metang": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/375"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/375"
         }
     },
     "metapod": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/011"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/011"
         }
     },
     "mew": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/151"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/151"
         }
     },
     "mewtwo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/150"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/150"
         }
     },
     "mienfoo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/619"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/619"
         }
     },
     "mienshao": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/620"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/620"
         }
     },
     "mightyena": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/262"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/262"
         }
     },
     "milcery": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/868"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/868"
         }
     },
     "milotic": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/350"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/350"
         }
     },
     "miltank": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/241"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/241"
         }
     },
     "mime-jr": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/439"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/439"
         }
     },
     "mimikyu": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/778"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/778"
         }
     },
     "minccino": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/572"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/572"
         }
     },
     "minior-meteor": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/774"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/774"
         }
     },
     "minun": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/312"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/312"
         }
     },
     "miraidon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1008"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1008"
         }
     },
     "misdreavus": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/200"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/200"
         }
     },
     "mismagius": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/429"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/429"
         }
     },
     "moltres": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/146"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/146"
         }
     },
     "monferno": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/391"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/391"
         }
     },
     "morelull": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/755"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/755"
         }
     },
     "morgrem": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/860"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/860"
         }
     },
     "morpeko": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/877"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/877"
         }
     },
     "mothim": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/414"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/414"
         }
     },
     "mr-mime": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/122"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/122"
         }
     },
     "mr-rime": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/866"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/866"
         }
     },
     "mudbray": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/749"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/749"
         }
     },
     "mudkip": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/258"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/258"
         }
     },
     "mudsdale": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/750"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/750"
         }
     },
     "muk": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/089"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/089"
         }
     },
     "munchlax": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/446"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/446"
         }
     },
     "munkidori": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1015"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1015"
         }
     },
     "munna": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/517"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/517"
         }
     },
     "murkrow": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/198"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/198"
         }
     },
     "musharna": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/518"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/518"
         }
     },
     "nacli": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/932"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/932"
         }
     },
     "naclstack": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/933"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/933"
         }
     },
     "naganadel": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/804"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/804"
         }
     },
     "natu": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/177"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/177"
         }
     },
     "necrozma": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/800"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/800"
         }
     },
     "necrozma-dawn-wings": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/800"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/800"
         }
     },
     "necrozma-dusk-mane": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/800"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/800"
         }
     },
     "necrozma-ultra": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/800"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/800"
         }
     },
     "nickit": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/827"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/827"
         }
     },
     "nidoking": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/034"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/034"
         }
     },
     "nidoqueen": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/031"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/031"
         }
     },
     "nidoran-f": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/029"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/029"
         }
     },
     "nidoran-m": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/032"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/032"
         }
     },
     "nidorina": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/030"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/030"
         }
     },
     "nidorino": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/033"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/033"
         }
     },
     "nihilego": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/793"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/793"
         }
     },
     "nincada": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/290"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/290"
         }
     },
     "ninetales": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/038"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/038"
         }
     },
     "ninjask": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/291"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/291"
         }
     },
     "noctowl": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/164"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/164"
         }
     },
     "noibat": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/714"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/714"
         }
     },
     "noivern": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/715"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/715"
         }
     },
     "nosepass": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/299"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/299"
         }
     },
     "numel": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/322"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/322"
         }
     },
     "nuzleaf": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/274"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/274"
         }
     },
     "nymble": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/919"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/919"
         }
     },
     "obstagoon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/862"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/862"
         }
     },
     "octillery": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/224"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/224"
         }
     },
     "oddish": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/043"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/043"
         }
     },
     "ogerpon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1017"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1017"
         }
     },
     "oinkologne": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/916"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/916"
         }
     },
     "okidogi": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1014"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1014"
         }
     },
     "omanyte": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/138"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/138"
         }
     },
     "omastar": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/139"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/139"
         }
     },
     "onix": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/095"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/095"
         }
     },
     "oranguru": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/765"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/765"
         }
     },
     "orbeetle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/826"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/826"
         }
     },
     "oricorio-baile": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/741"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/741"
         }
     },
     "oricorio-pom-pom": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/741"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/741"
         }
     },
     "orthworm": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/968"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/968"
         }
     },
     "oshawott": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/501"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/501"
         }
     },
     "overqwil": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/904"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/904"
         }
     },
     "pachirisu": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/417"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/417"
         }
     },
     "palafin": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/964"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/964"
         }
     },
     "palafin-hero": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/964"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/964"
         }
     },
     "paldean-tauros": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/128"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/128"
         }
     },
     "paldean-tauros-aqua": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/128"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/128"
         }
     },
     "paldean-tauros-blaze": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/128"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/128"
         }
     },
     "paldean-wooper": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/194"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/194"
         }
     },
     "palkia": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/484"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/484"
         }
     },
     "palkia-origin": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/484"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/484"
         }
     },
     "palossand": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/770"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/770"
         }
     },
     "palpitoad": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/536"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/536"
         }
     },
     "pancham": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/674"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/674"
         }
     },
     "pangoro": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/675"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/675"
         }
     },
     "panpour": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/514"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/514"
         }
     },
     "pansage": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/511"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/511"
         }
     },
     "pansear": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/513"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/513"
         }
     },
     "paras": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/046"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/046"
         }
     },
     "parasect": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/047"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/047"
         }
     },
     "passimian": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/766"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/766"
         }
     },
     "patrat": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/504"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/504"
         }
     },
     "pawmi": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/921"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/921"
         }
     },
     "pawmo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/922"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/922"
         }
     },
     "pawmot": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/923"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/923"
         }
     },
     "pawniard": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/624"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/624"
         }
     },
     "pecharunt": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1025"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1025"
         }
     },
     "pelipper": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/279"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/279"
         }
     },
     "perrserker": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/863"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/863"
         }
     },
     "persian": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/053"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/053"
         }
     },
     "petilil": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/548"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/548"
         }
     },
     "phanpy": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/231"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/231"
         }
     },
     "phantump": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/708"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/708"
         }
     },
     "pheromosa": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/795"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/795"
         }
     },
     "phione": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/489"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/489"
         }
     },
     "pichu": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/172"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/172"
         }
     },
     "pidgeot": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/018"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/018"
         }
     },
     "pidgeotto": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/017"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/017"
         }
     },
     "pidgey": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/016"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/016"
         }
     },
     "pidove": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/519"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/519"
         }
     },
     "pignite": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/499"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/499"
         }
     },
     "pikachu": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/025"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/025"
         }
     },
     "pikipek": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/731"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/731"
         }
     },
     "piloswine": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/221"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/221"
         }
     },
     "pincurchin": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/871"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/871"
         }
     },
     "pineco": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/204"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/204"
         }
     },
     "pinsir": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/127"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/127"
         }
     },
     "piplup": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/393"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/393"
         }
     },
     "plusle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/311"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/311"
         }
     },
     "poipole": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/803"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/803"
         }
     },
     "politoed": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/186"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/186"
         }
     },
     "poliwag": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/060"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/060"
         }
     },
     "poliwhirl": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/061"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/061"
         }
     },
     "poliwrath": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/062"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/062"
         }
     },
     "poltchageist": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1012"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1012"
         }
     },
     "polteageist": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/855"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/855"
         }
     },
     "ponyta": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/077"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/077"
         }
     },
     "poochyena": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/261"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/261"
         }
     },
     "popplio": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/728"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/728"
         }
     },
     "porygon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/137"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/137"
         }
     },
     "porygon-z": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/474"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/474"
         }
     },
     "porygon2": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/233"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/233"
         }
     },
     "primarina": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/730"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/730"
         }
     },
     "primeape": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/057"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/057"
         }
     },
     "prinplup": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/394"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/394"
         }
     },
     "probopass": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/476"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/476"
         }
     },
     "psyduck": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/054"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/054"
         }
     },
     "pumpkaboo-average": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/710"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/710"
         }
     },
     "pupitar": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/247"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/247"
         }
     },
     "purrloin": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/509"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/509"
         }
     },
     "purugly": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/432"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/432"
         }
     },
     "pyroar-female": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/668"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/668"
         }
     },
     "pyroar-male": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/668"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/668"
         }
     },
     "pyukumuku": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/771"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/771"
         }
     },
     "quagsire": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/195"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/195"
         }
     },
     "quaquaval": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/914"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/914"
         }
     },
     "quaxly": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/912"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/912"
         }
     },
     "quaxwell": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/913"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/913"
         }
     },
     "quilava": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/156"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/156"
         }
     },
     "quilladin": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/651"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/651"
         }
     },
     "qwilfish": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/211"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/211"
         }
     },
     "raboot": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/814"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/814"
         }
     },
     "rabsca": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/954"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/954"
         }
     },
     "raging-bolt": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1021"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1021"
         }
     },
     "raichu": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/026"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/026"
         }
     },
     "raikou": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/243"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/243"
         }
     },
     "ralts": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/280"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/280"
         }
     },
     "rampardos": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/409"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/409"
         }
     },
     "rapidash": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/078"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/078"
         }
     },
     "raticate": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/020"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/020"
         }
     },
     "rattata": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/019"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/019"
         }
     },
     "rayquaza": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/384"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/384"
         }
     },
     "regice": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/378"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/378"
         }
     },
     "regidrago": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/895"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/895"
         }
     },
     "regieleki": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/894"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/894"
         }
     },
     "regigigas": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/486"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/486"
         }
     },
     "regirock": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/377"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/377"
         }
     },
     "registeel": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/379"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/379"
         }
     },
     "relicanth": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/369"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/369"
         }
     },
     "rellor": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/953"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/953"
         }
     },
     "remoraid": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/223"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/223"
         }
     },
     "reshiram": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/643"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/643"
         }
     },
     "reuniclus": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/579"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/579"
         }
     },
     "revavroom": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/966"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/966"
         }
     },
     "rhydon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/112"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/112"
         }
     },
     "rhyhorn": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/111"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/111"
         }
     },
     "rhyperior": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/464"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/464"
         }
     },
     "ribombee": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/743"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/743"
         }
     },
     "rillaboom": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/812"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/812"
         }
     },
     "riolu": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/447"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/447"
         }
     },
     "roaring-moon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1005"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1005"
         }
     },
     "rockruff": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/744"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/744"
         }
     },
     "roggenrola": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/524"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/524"
         }
     },
     "rolycoly": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/837"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/837"
         }
     },
     "rookidee": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/821"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/821"
         }
     },
     "roselia": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/315"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/315"
         }
     },
     "roserade": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/407"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/407"
         }
     },
     "rotom": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/479"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/479"
         },
         "suffixes": {
             "wash": "_Wash",
@@ -4132,1517 +4132,1517 @@
     },
     "rotom-fan": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/479"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/479"
         }
     },
     "rotom-frost": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/479"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/479"
         }
     },
     "rotom-mow": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/479"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/479"
         }
     },
     "rotom-wash": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/479"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/479"
         }
     },
     "rowlet": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/722"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/722"
         }
     },
     "rufflet": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/627"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/627"
         }
     },
     "runerigus": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/867"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/867"
         }
     },
     "sableye": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/302"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/302"
         }
     },
     "salamence": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/373"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/373"
         }
     },
     "salandit": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/757"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/757"
         }
     },
     "salazzle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/758"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/758"
         }
     },
     "samurott": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/503"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/503"
         }
     },
     "sandaconda": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/844"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/844"
         }
     },
     "sandile": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/551"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/551"
         }
     },
     "sandshrew": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/027"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/027"
         }
     },
     "sandslash": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/028"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/028"
         }
     },
     "sandy-shocks": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/989"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/989"
         }
     },
     "sandygast": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/769"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/769"
         }
     },
     "sawk": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/539"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/539"
         }
     },
     "sawsbuck": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/586"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/586"
         }
     },
     "scatterbug": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/664"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/664"
         }
     },
     "sceptile": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/254"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/254"
         }
     },
     "scizor": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/212"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/212"
         }
     },
     "scolipede": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/545"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/545"
         }
     },
     "scorbunny": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/813"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/813"
         }
     },
     "scovillain": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/952"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/952"
         }
     },
     "scrafty": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/560"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/560"
         }
     },
     "scraggy": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/559"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/559"
         }
     },
     "scream-tail": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/985"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/985"
         }
     },
     "scyther": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/123"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/123"
         }
     },
     "seadra": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/117"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/117"
         }
     },
     "seaking": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/119"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/119"
         }
     },
     "sealeo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/364"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/364"
         }
     },
     "seedot": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/273"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/273"
         }
     },
     "seel": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/086"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/086"
         }
     },
     "seismitoad": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/537"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/537"
         }
     },
     "sentret": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/161"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/161"
         }
     },
     "serperior": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/497"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/497"
         }
     },
     "servine": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/496"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/496"
         }
     },
     "seviper": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/336"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/336"
         }
     },
     "sewaddle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/540"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/540"
         }
     },
     "sharpedo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/319"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/319"
         }
     },
     "shaymin-land": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/492"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/492"
         }
     },
     "shedinja": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/292"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/292"
         }
     },
     "shelgon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/372"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/372"
         }
     },
     "shellder": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/090"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/090"
         }
     },
     "shellos": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/422"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/422"
         }
     },
     "shelmet": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/616"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/616"
         }
     },
     "shieldon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/410"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/410"
         }
     },
     "shiftry": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/275"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/275"
         }
     },
     "shiinotic": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/756"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/756"
         }
     },
     "shinx": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/403"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/403"
         }
     },
     "shroodle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/944"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/944"
         }
     },
     "shroomish": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/285"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/285"
         }
     },
     "shuckle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/213"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/213"
         }
     },
     "shuppet": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/353"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/353"
         }
     },
     "sigilyph": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/561"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/561"
         }
     },
     "silcoon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/266"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/266"
         }
     },
     "silicobra": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/843"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/843"
         }
     },
     "silvally": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/773"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/773"
         }
     },
     "simipour": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/516"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/516"
         }
     },
     "simisage": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/512"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/512"
         }
     },
     "simisear": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/514"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/514"
         }
     },
     "sinistcha": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1013"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1013"
         }
     },
     "sinistea": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/854"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/854"
         }
     },
     "sirfetchd": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/865"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/865"
         }
     },
     "sizzlipede": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/850"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/850"
         }
     },
     "skarmory": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/227"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/227"
         }
     },
     "skeledirge": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/911"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/911"
         }
     },
     "skiddo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/672"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/672"
         }
     },
     "skiploom": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/188"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/188"
         }
     },
     "skitty": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/300"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/300"
         }
     },
     "skorupi": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/451"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/451"
         }
     },
     "skrelp": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/690"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/690"
         }
     },
     "skuntank": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/435"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/435"
         }
     },
     "skwovet": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/819"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/819"
         }
     },
     "slaking": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/289"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/289"
         }
     },
     "slakoth": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/287"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/287"
         }
     },
     "sliggoo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/705"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/705"
         }
     },
     "slither-wing": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/988"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/988"
         }
     },
     "slowbro": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/080"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/080"
         }
     },
     "slowking": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/199"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/199"
         }
     },
     "slowpoke": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/079"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/079"
         }
     },
     "slugma": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/218"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/218"
         }
     },
     "slurpuff": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/685"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/685"
         }
     },
     "smeargle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/235"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/235"
         }
     },
     "smoliv": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/928"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/928"
         }
     },
     "smoochum": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/238"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/238"
         }
     },
     "sneasel": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/215"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/215"
         }
     },
     "sneasler": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/903"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/903"
         }
     },
     "snivy": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/495"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/495"
         }
     },
     "snom": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/872"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/872"
         }
     },
     "snorlax": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/143"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/143"
         }
     },
     "snorunt": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/361"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/361"
         }
     },
     "snover": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/459"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/459"
         }
     },
     "snubbull": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/209"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/209"
         }
     },
     "sobble": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/816"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/816"
         }
     },
     "solgaleo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/791"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/791"
         }
     },
     "solosis": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/577"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/577"
         }
     },
     "solrock": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/338"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/338"
         }
     },
     "spearow": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/021"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/021"
         }
     },
     "spectrier": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/897"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/897"
         }
     },
     "spewpa": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/665"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/665"
         }
     },
     "spheal": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/363"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/363"
         }
     },
     "spidops": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/918"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/918"
         }
     },
     "spinarak": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/167"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/167"
         }
     },
     "spinda": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/327"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/327"
         }
     },
     "spiritomb": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/442"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/442"
         }
     },
     "spoink": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/325"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/325"
         }
     },
     "sprigatito": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/906"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/906"
         }
     },
     "spritzee": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/682"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/682"
         }
     },
     "squawkabilly": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/931"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/931"
         }
     },
     "squirtle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/007"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/007"
         }
     },
     "stakataka": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/805"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/805"
         }
     },
     "stantler": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/234"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/234"
         }
     },
     "staraptor": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/398"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/398"
         }
     },
     "staravia": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/397"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/397"
         }
     },
     "starly": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/396"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/396"
         }
     },
     "starmie": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/121"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/121"
         }
     },
     "staryu": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/120"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/120"
         }
     },
     "steelix": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/208"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/208"
         }
     },
     "steenee": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/762"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/762"
         }
     },
     "stonjourner": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/874"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/874"
         }
     },
     "stoutland": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/508"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/508"
         }
     },
     "stufful": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/759"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/759"
         }
     },
     "stunfisk": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/618"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/618"
         }
     },
     "stunky": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/434"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/434"
         }
     },
     "sudowoodo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/185"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/185"
         }
     },
     "suicune": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/245"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/245"
         }
     },
     "sunflora": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/192"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/192"
         }
     },
     "sunkern": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/191"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/191"
         }
     },
     "surskit": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/283"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/283"
         }
     },
     "swablu": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/333"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/333"
         }
     },
     "swadloon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/541"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/541"
         }
     },
     "swalot": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/317"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/317"
         }
     },
     "swampert": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/260"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/260"
         }
     },
     "swanna": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/581"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/581"
         }
     },
     "swellow": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/277"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/277"
         }
     },
     "swinub": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/220"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/220"
         }
     },
     "swirlix": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/684"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/684"
         }
     },
     "swoobat": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/528"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/528"
         }
     },
     "sylveon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/700"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/700"
         }
     },
     "tadbulb": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/938"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/938"
         }
     },
     "taillow": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/276"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/276"
         }
     },
     "talonflame": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/663"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/663"
         }
     },
     "tandemaus": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/924"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/924"
         }
     },
     "tangela": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/114"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/114"
         }
     },
     "tangrowth": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/465"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/465"
         }
     },
     "tapu-bulu": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/787"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/787"
         }
     },
     "tapu-fini": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/788"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/788"
         }
     },
     "tapu-koko": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/785"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/785"
         }
     },
     "tapu-lele": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/786"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/786"
         }
     },
     "tarountula": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/917"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/917"
         }
     },
     "tatsugiri": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/978"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/978"
         }
     },
     "tauros": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/128"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/128"
         }
     },
     "teddiursa": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/216"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/216"
         }
     },
     "tentacool": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/072"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/072"
         }
     },
     "tentacruel": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/073"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/073"
         }
     },
     "tepig": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/498"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/498"
         }
     },
     "terapagos-normal": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1024"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1024"
         }
     },
     "terapagos-stellar": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1024"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1024"
         }
     },
     "terapagos-terastal": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1024"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1024"
         }
     },
     "terrakion": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/639"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/639"
         }
     },
     "thievul": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/828"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/828"
         }
     },
     "throh": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/538"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/538"
         }
     },
     "thundurus-incarnate": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/642"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/642"
         }
     },
     "thundurus-therian": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/642"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/642"
         }
     },
     "thwackey": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/811"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/811"
         }
     },
     "timburr": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/532"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/532"
         }
     },
     "ting-lu": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1003"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1003"
         }
     },
     "tinkatink": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/957"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/957"
         }
     },
     "tinkaton": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/959"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/959"
         }
     },
     "tinkatuff": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/958"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/958"
         }
     },
     "tirtouga": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/564"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/564"
         }
     },
     "toedscool": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/948"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/948"
         }
     },
     "toedscruel": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/949"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/949"
         }
     },
     "togedemaru": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/777"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/777"
         }
     },
     "togekiss": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/468"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/468"
         }
     },
     "togepi": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/175"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/175"
         }
     },
     "togetic": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/176"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/176"
         }
     },
     "torchic": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/255"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/255"
         }
     },
     "torkoal": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/324"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/324"
         }
     },
     "tornadus-incarnate": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/641"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/641"
         }
     },
     "tornadus-therian": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/641"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/641"
         }
     },
     "torracat": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/726"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/726"
         }
     },
     "torterra": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/389"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/389"
         }
     },
     "totodile": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/158"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/158"
         }
     },
     "toucannon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/733"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/733"
         }
     },
     "toxapex": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/748"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/748"
         }
     },
     "toxel": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/848"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/848"
         }
     },
     "toxicroak": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/454"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/454"
         }
     },
     "toxtricity": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/849"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/849"
         }
     },
     "tranquill": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/520"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/520"
         }
     },
     "trapinch": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/328"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/328"
         }
     },
     "treecko": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/252"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/252"
         }
     },
     "trevenant": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/709"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/709"
         }
     },
     "tropius": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/357"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/357"
         }
     },
     "trubbish": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/568"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/568"
         }
     },
     "trumbeak": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/732"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/732"
         }
     },
     "tsareena": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/763"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/763"
         }
     },
     "turtonator": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/776"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/776"
         }
     },
     "turtwig": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/387"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/387"
         }
     },
     "tympole": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/535"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/535"
         }
     },
     "tynamo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/602"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/602"
         }
     },
     "type-null": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/772"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/772"
         }
     },
     "typhlosion": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/157"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/157"
         }
     },
     "tyranitar": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/248"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/248"
         }
     },
     "tyrantrum": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/697"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/697"
         }
     },
     "tyrogue": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/236"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/236"
         }
     },
     "tyrunt": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/696"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/696"
         }
     },
     "umbreon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/197"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/197"
         }
     },
     "unfezant": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/521"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/521"
         }
     },
     "unown": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/201"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/201"
         }
     },
     "ursaluna": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/901"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/901"
         }
     },
     "ursaluna-bloodmoon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/901"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/901"
         }
     },
     "ursaring": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/217"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/217"
         }
     },
     "urshifu-rapid-strike": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/892"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/892"
         }
     },
     "urshifu-single-strike": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/892"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/892"
         }
     },
     "uxie": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/480"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/480"
         }
     },
     "vanillish": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/583"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/583"
         }
     },
     "vanillite": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/582"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/582"
         }
     },
     "vanilluxe": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/584"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/584"
         }
     },
     "vaporeon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/134"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/134"
         }
     },
     "varoom": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/965"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/965"
         }
     },
     "veluza": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/976"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/976"
         }
     },
     "venipede": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/543"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/543"
         }
     },
     "venomoth": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/049"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/049"
         }
     },
     "venonat": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/048"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/048"
         }
     },
     "venusaur": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/003"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/003"
         }
     },
     "vespiquen": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/416"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/416"
         }
     },
     "vibrava": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/329"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/329"
         }
     },
     "victini": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/494"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/494"
         }
     },
     "victreebel": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/071"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/071"
         }
     },
     "vigoroth": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/288"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/288"
         }
     },
     "vikavolt": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/738"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/738"
         }
     },
     "vileplume": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/045"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/045"
         }
     },
     "virizion": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/640"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/640"
         }
     },
     "vivillon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/666"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/666"
         }
     },
     "volbeat": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/313"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/313"
         }
     },
     "volcanion": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/721"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/721"
         }
     },
     "volcarona": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/637"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/637"
         }
     },
     "voltorb": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/100"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/100"
         }
     },
     "vullaby": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/629"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/629"
         }
     },
     "vulpix": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/037"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/037"
         }
     },
     "wailmer": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/320"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/320"
         }
     },
     "wailord": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/321"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/321"
         }
     },
     "walking-wake": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1009"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1009"
         }
     },
     "walrein": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/365"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/365"
         }
     },
     "wartortle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/008"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/008"
         }
     },
     "watchog": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/505"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/505"
         }
     },
     "wattrel": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/940"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/940"
         }
     },
     "weavile": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/461"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/461"
         }
     },
     "weedle": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/013"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/013"
         }
     },
     "weepinbell": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/070"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/070"
         }
     },
     "weezing": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/110"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/110"
         }
     },
     "whimsicott": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/547"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/547"
         }
     },
     "whirlipede": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/544"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/544"
         }
     },
     "whiscash": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/340"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/340"
         }
     },
     "whismur": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/293"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/293"
         }
     },
     "wigglytuff": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/040"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/040"
         }
     },
     "wiglett": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/960"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/960"
         }
     },
     "wimpod": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/767"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/767"
         }
     },
     "wingull": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/278"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/278"
         }
     },
     "wishiwashi-solo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/746"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/746"
         }
     },
     "wo-chien": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/1001"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/1001"
         }
     },
     "wobbuffet": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/202"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/202"
         }
     },
     "woobat": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/527"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/527"
         }
     },
     "wooloo": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/831"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/831"
         }
     },
     "wooper": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/194"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/194"
         }
     },
     "wormadam-plant": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/413"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/413"
         }
     },
     "wormadam-sandy": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/413"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/413"
         }
     },
     "wormadam-trash": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/413"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/413"
         }
     },
     "wugtrio": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/961"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/961"
         }
     },
     "wurmple": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/265"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/265"
         }
     },
     "wynaut": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/360"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/360"
         }
     },
     "wyrdeer": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/899"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/899"
         }
     },
     "xatu": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/178"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/178"
         }
     },
     "xerneas": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/716"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/716"
         }
     },
     "xurkitree": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/796"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/796"
         }
     },
     "yamask": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/562"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/562"
         }
     },
     "yamper": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/835"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/835"
         }
     },
     "yanma": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/193"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/193"
         }
     },
     "yanmega": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/469"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/469"
         }
     },
     "yungoos": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/734"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/734"
         }
     },
     "yveltal": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/717"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/717"
         }
     },
     "zacian-crowned": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/888"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/888"
         }
     },
     "zacian-hero": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/888"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/888"
         }
     },
     "zamazenta-crowned": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/889"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/889"
         }
     },
     "zamazenta-hero": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/889"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/889"
         }
     },
     "zangoose": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/335"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/335"
         }
     },
     "zapdos": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/145"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/145"
         }
     },
     "zarude": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/893"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/893"
         }
     },
     "zebstrika": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/523"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/523"
         }
     },
     "zekrom": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/644"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/644"
         }
     },
     "zeraora": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/807"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/807"
         }
     },
     "zigzagoon": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/263"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/263"
         }
     },
     "zoroark": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/571"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/571"
         }
     },
     "zorua": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/570"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/570"
         }
     },
     "zubat": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/041"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/041"
         }
     },
     "zweilous": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/634"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/634"
         }
     },
     "zygarde-10": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/718"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/718"
         }
     },
     "zygarde-50": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/718"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/718"
         }
     },
     "zygarde-complete": {
         "data": {
-            "base": "/modules/ptr2e-pkmn-sprites/sprites/718"
+            "base": "modules/ptr2e-pkmn-sprites/sprites/718"
         }
     }
 }

--- a/module.json
+++ b/module.json
@@ -26,7 +26,7 @@
   ],
   "flags": {
     "ptr2e-pkmn-sprites": {
-        "ptr2e-species-art": "/modules/ptr2e-pkmn-sprites/artmap.json",
+        "ptr2e-species-art": "modules/ptr2e-pkmn-sprites/artmap.json",
         "ptr2e-species-art-priority": 0
     }
   },


### PR DESCRIPTION
In part fixes [#538 in ptr2e](https://github.com/pokemon-tabletop-reunited/ptr2e/issues/538)